### PR TITLE
Updating rules,yml

### DIFF
--- a/textlint/rules.yml
+++ b/textlint/rules.yml
@@ -12,6 +12,9 @@ rules:
   - expected: ドキュメント
     patterns:
       - 文書
+  - expected: インナーソース
+    patterns:
+      - InnerSource
 # 人名と社名
   - expected: PayPal
     patterns:

--- a/textlint/rules.yml
+++ b/textlint/rules.yml
@@ -1,4 +1,28 @@
 rules:
-  - expected: サーバー
+# 訳語の統一
+  - expected: ユニットテスト
     patterns:
-      - サーバ
+      - 単体テスト
+  - expected: リポジトリ
+    patterns:
+      - レポジトリ
+  - expected: コントリビューション
+    patterns:
+      - 貢献
+  - expected: ドキュメント
+    patterns:
+      - 文書
+# 人名と社名
+  - expected: PayPal
+    patterns:
+      - paypal
+      - Paypal
+      - payPal
+      - ペイパル
+# その他
+  - expected: (
+    patterns:
+      - （
+  - expected: )
+    patterns:
+      - ）


### PR DESCRIPTION
# やったこと
textlint の prh という仕組みを用いて訳語の統一などをチェックできるようにした。
対応した語句
- コントリビューション / 貢献 → コントリビューション
- リポジトリ / レポジトリ → リポジトリ
- 単体テスト / ユニットテスト → ユニットテスト
- InnerSource / インナーソース → インナーソース
- ドキュメント/文書 → ドキュメント
- 全角かっこ（）/ 半角かっこ () → 半角かっこ ()
- paypal / Paypal / payPal / ペイパル → PayPal

# やらなかったこと
- **このルールに沿った形への修正**
- 人名のカタカナ・アルファベットの統一
- カタカナ英語の長音 (例 : ユーザー or ユーザ → ユーザー)
  - textlint のルールで対応しようとしたがまだリリースされていないルールだった。
- 句読点の統一 ( 、 。 にする )
- [全角語句と半角語句の間](https://github.com/InnerSourceCommons/jp-contents/blob/main/TRANSLATION-POLICY.md#%E5%85%A8%E8%A7%92%E8%AA%9E%E5%8F%A5%E3%81%A8%E5%8D%8A%E8%A7%92%E8%AA%9E%E5%8F%A5%E3%81%AE%E9%96%93)

