### PR TITLE
Update Textlint

### DIFF
--- a/textlint/.textlintrc
+++ b/textlint/.textlintrc
@@ -22,7 +22,11 @@
         "preferInList": ""
       },
       "ja-no-weak-phrase": false,
-      "no-exclamation-question-mark": false
+      "no-exclamation-question-mark": false,
+      "no-doubled-joshi": {
+        "min_interval" : 2,
+        "allow": ["ど", "も", "や"]
+      }
     }
   },
   "filters": {

--- a/textlint/.textlintrc
+++ b/textlint/.textlintrc
@@ -22,9 +22,7 @@
         "preferInList": ""
       },
       "ja-no-weak-phrase": false,
-      "no-exclamation-question-mark": {
-        "severity": "warning"
-      }
+      "no-exclamation-question-mark": false
     }
   },
   "filters": {


### PR DESCRIPTION
Understanding the InnerSource Checklist の翻訳を機に Textlint のルールを見直します

- 感嘆符(！、？) を許容します。このルールは論文向けであり、デフォルトで error だったのを warning にしたのですが、warning に沿って消す翻訳メンバーが出たため、完全に許容します。このリポジトリで扱う文書は技術文書ですが、必ずしも純粋な論説文ではなく、ときに随筆的な表現を含むためです。
- 助詞を連続するルールを緩和します。
    - 何もかも、あれやこれや、待てど暮せど、というフレーズを利用するため、"ど", "も", "や" については連続してもよいことにします。
    - https://github.com/textlint-ja/textlint-rule-no-doubled-joshi