### PR TITLE
Fix the top of .gitbook.yaml

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,4 +1,2 @@
 # In the deployment process, this file is copied to the root of the book
 # Root should be set to the relative path to the book from the root of the repo
-root: ./books/Understanding-the-InnerSource-Checklist/
-


### PR DESCRIPTION
9章 #76 でトップにある .gitbook.yaml に不要な変更が入っていることがわかりましたので、これを戻します。
これをマージしてから GitBook 関係の workflow が失敗しているように見えます。
https://github.com/InnerSourceCommons/jp-contents/actions/workflows/gitbook-branch-deploy.yml
